### PR TITLE
Use the static endpoint for downloading crates to load crates.io less

### DIFF
--- a/criner/src/engine/work/schedule.rs
+++ b/criner/src/engine/work/schedule.rs
@@ -63,7 +63,7 @@ pub async fn tasks(
             crate_name_and_version: Some((krate.name.clone(), krate.version.clone())),
             kind,
             url: format!(
-                "https://crates.io/api/v1/crates/{name}/{version}/download",
+                "https://static.crates.io/crates/{name}/{name}-{version}.crate",
                 name = krate.name,
                 version = krate.version
             ),


### PR DESCRIPTION
Per advice on https://www.pietroalbini.org/blog/downloading-crates-io/