### PR TITLE
chore(ci): cache rust and split into multiple jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,11 +43,3 @@ jobs:
         cargo diet -n --package-size-limit 15KB
         (cd criner && cargo diet -n --package-size-limit 50KB)
         (cd criner-waste-report && cargo diet -n --package-size-limit 18KB)
-
-  stress:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v7
-    - uses: Swatinem/rust-cache@v2
-    - name: stress
-      run: make mine-2min-logonly && du -sch criner.db/*

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,19 +7,47 @@ on:
     branches: [ main ]
 
 jobs:
-  build-and-test:
+  fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: tests
-      run: make tests
-    - name: stress
-      run: make mine-2min-logonly && du -sch criner.db/*
+    - uses: actions/checkout@v7
+    - uses: Swatinem/rust-cache@v2
+    - run: make fmt
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - uses: Swatinem/rust-cache@v2
+    - run: make clippy
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo check --all --tests
+    - run: cd criner-waste-report && cargo check --tests && cargo check --tests --no-default-features
+    - run: cargo test --all
+
+  package-size:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - uses: Swatinem/rust-cache@v2
     - name: Check crate package size
       run: |
         curl -LSfs https://raw.githubusercontent.com/the-lean-crate/cargo-diet/master/ci/install.sh | \
-         sh -s -- --git the-lean-crate/cargo-diet --tag v1.2.7 --target x86_64-unknown-linux-musl
+         sh -s -- --git the-lean-crate/cargo-diet --tag v1.4.0 --target x86_64-unknown-linux-musl
 
         cargo diet -n --package-size-limit 15KB
         (cd criner && cargo diet -n --package-size-limit 50KB)
         (cd criner-waste-report && cargo diet -n --package-size-limit 18KB)
+
+  stress:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - uses: Swatinem/rust-cache@v2
+    - name: stress
+      run: make mine-2min-logonly && du -sch criner.db/*


### PR DESCRIPTION
CI takes around 15 minutes now, caching and splitting the jobs should make the full thing take much less time. Many jobs rebuild the full crate, taking 3ish minutes each time

EDIT: the pipeline now takes 36 seconds. I removed the stress job as well since it's been failing for a long time now and will be replaced